### PR TITLE
build: Remove beaker-plugin-safe-app from the list of published docs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-repos=("safe_app_nodejs" "beaker-plugin-safe-app" "Whitepapers")
+repos=("safe_app_nodejs" "Whitepapers")
 for i in "${repos[@]}"; do
   target="dist/$i"
   git clone --depth 1 --branch gh-pages https://github.com/maidsafe/$i $target


### PR DESCRIPTION
Since we are deprecating our Beaker browser, and the new DOM API is different from beaker plugin API we should remove this documentation to avoid confusing developers. New browser's DOM API doc is now being added to its README file